### PR TITLE
Add Jest tests for range serialization

### DIFF
--- a/__tests__/serialization.test.js
+++ b/__tests__/serialization.test.js
@@ -1,0 +1,40 @@
+const { serializeRange, deserializeRange } = require('../content_script');
+
+describe('range serialization', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('round trip preserves range', () => {
+    document.body.innerHTML = '<p>Hello <em>World</em>!</p>';
+    const p = document.querySelector('p');
+    const text1 = p.firstChild; // "Hello "
+    const text2 = p.querySelector('em').firstChild; // "World"
+    const range = document.createRange();
+    range.setStart(text1, 1);
+    range.setEnd(text2, 3);
+
+    const info = serializeRange(range);
+    const restored = deserializeRange(info);
+
+    expect(restored.toString()).toBe(range.toString());
+    expect(restored.startContainer).toBe(text1);
+    expect(restored.startOffset).toBe(1);
+    expect(restored.endContainer).toBe(text2);
+    expect(restored.endOffset).toBe(3);
+  });
+
+  test('deserializeRange returns null for invalid path', () => {
+    document.body.innerHTML = '<p>Hello</p>';
+    const p = document.querySelector('p');
+    const text = p.firstChild;
+    const range = document.createRange();
+    range.setStart(text, 0);
+    range.setEnd(text, text.textContent.length);
+
+    const info = serializeRange(range);
+    info.startPath.push(99); // create bad path
+    const invalid = deserializeRange(info);
+    expect(invalid).toBeNull();
+  });
+});

--- a/content_script.js
+++ b/content_script.js
@@ -218,3 +218,8 @@ if (document.readyState === 'loading') {
     loadSavedSnippets();
     document.querySelectorAll('.oneclick-snippet').forEach(injectCopyPill);
 }
+
+// Export functions for testing in Node environments
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { serializeRange, deserializeRange };
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "Chrome extension to copy selected text snippets in Google Docs.",
   "scripts": {
-    "test": "echo \"No test suite\""
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# Requirements for running tests
+jest==29.7.0


### PR DESCRIPTION
## Summary
- add Jest dev dependency and test script
- export serialization helpers for Node
- test serializeRange/deserializeRange round-trip behavior
- include requirements.txt listing dev dependencies

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f81e083d08321b68771d3be6b74b3