### PR TITLE
Add alias badge test and jest config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/__tests__/wrapSnippet.test.js
+++ b/__tests__/wrapSnippet.test.js
@@ -1,0 +1,27 @@
+const { wrapRangeWithSnippet } = require('../content_script');
+
+describe('wrapRangeWithSnippet', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<p id="p">Hello World</p>';
+  });
+
+  test('wraps selection with span and badge', () => {
+    const p = document.getElementById('p');
+    const textNode = p.firstChild;
+    const range = document.createRange();
+    range.setStart(textNode, 0);
+    range.setEnd(textNode, 5); // "Hello"
+
+    const meta = { snippetId: '123', alias: 'Greet' };
+    wrapRangeWithSnippet(range, meta);
+
+    const span = p.querySelector('span.oneclick-snippet');
+    expect(span).not.toBeNull();
+    expect(span.dataset.snippetId).toBe('123');
+    expect(span.dataset.alias).toBe('Greet');
+
+    const badge = span.querySelector('.snippet-badge');
+    expect(badge).not.toBeNull();
+    expect(badge.textContent).toBe('Greet');
+  });
+});

--- a/content_script.js
+++ b/content_script.js
@@ -224,5 +224,5 @@ if (typeof document !== 'undefined') {
 
 // Export functions for testing in Node environments
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { serializeRange, deserializeRange };
+    module.exports = { serializeRange, deserializeRange, wrapRangeWithSnippet };
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+};


### PR DESCRIPTION
## Summary
- configure Jest with jsdom
- export `wrapRangeWithSnippet` for testing
- test snippet wrapping behavior
- ignore `node_modules` and `package-lock.json`

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6871d96b5c3083219c8b26f69ca7a398