### PR TITLE
Fix chrome storage checks

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -108,6 +108,9 @@ function wrapRangeWithSnippet(range, meta) {
 
 // Save a snippet’s metadata to chrome.storage.sync
 function saveSnippetMeta(meta) {
+    if (typeof chrome === 'undefined' || !chrome.storage || !chrome.storage.sync) {
+        return;
+    }
     chrome.storage.sync.get([DOC_KEY], data => {
         const arr = data[DOC_KEY] || [];
         arr.push(meta);
@@ -117,6 +120,9 @@ function saveSnippetMeta(meta) {
 
 // Load & rehydrate all snippets for this doc
 function loadSavedSnippets() {
+    if (typeof chrome === 'undefined' || !chrome.storage || !chrome.storage.sync) {
+        return;
+    }
     chrome.storage.sync.get([DOC_KEY], data => {
         const arr = data[DOC_KEY] || [];
         arr.forEach(meta => {
@@ -213,11 +219,15 @@ if (typeof document !== 'undefined') {
     // 3) On-load rehydrate snippets
     if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', () => {
-            loadSavedSnippets();
+            if (typeof chrome !== 'undefined') {
+                loadSavedSnippets();
+            }
             document.querySelectorAll('.oneclick-snippet').forEach(injectCopyPill);
         });
     } else {
-        loadSavedSnippets();
+        if (typeof chrome !== 'undefined') {
+            loadSavedSnippets();
+        }
         document.querySelectorAll('.oneclick-snippet').forEach(injectCopyPill);
     }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "test": "jest"
   },
   "devDependencies": {
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^30.0.4"
+  },
+  "dependencies": {
+    "jsdom": "^26.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- guard against missing `chrome.storage.sync` in `content_script`
- enable jsdom test environment for Jest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871dd726e5083219760bce8647286cc