### PR TITLE
Add customizable appearance options

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -6,6 +6,45 @@ console.log('One-Click Snippets content script loaded.');
 // CONFIG
 const SNIPPET_BTN_ID = 'ocs-snippet-button';
 const DOC_KEY = (typeof location !== 'undefined' ? location.pathname : ''); // e.g. "/document/d/…"
+const DEFAULT_APPEARANCE = { color: '#4A90E2', border: '2px dashed' };
+let appearance = { ...DEFAULT_APPEARANCE };
+loadAppearance(() => {
+    document.querySelectorAll('.oneclick-snippet').forEach(applyAppearanceToSpan);
+});
+
+function loadAppearance(cb) {
+    if (typeof chrome === 'undefined' || !chrome.storage || !chrome.storage.sync) {
+        cb && cb();
+        return;
+    }
+    chrome.storage.sync.get({ appearance: DEFAULT_APPEARANCE }, data => {
+        appearance = data.appearance || DEFAULT_APPEARANCE;
+        cb && cb();
+    });
+}
+
+function hexToRgba(hex, alpha) {
+    hex = hex.replace('#','');
+    if (hex.length === 3) {
+        const r = parseInt(hex[0] + hex[0], 16);
+        const g = parseInt(hex[1] + hex[1], 16);
+        const b = parseInt(hex[2] + hex[2], 16);
+        return `rgba(${r},${g},${b},${alpha})`;
+    } else if (hex.length === 6) {
+        const bigint = parseInt(hex, 16);
+        const r = (bigint >> 16) & 255;
+        const g = (bigint >> 8) & 255;
+        const b = bigint & 255;
+        return `rgba(${r},${g},${b},${alpha})`;
+    }
+    return `rgba(0,0,0,${alpha})`;
+}
+
+function applyAppearanceToSpan(span) {
+    if (!span) return;
+    span.style.border = `${appearance.border} ${appearance.color}`;
+    span.style.background = hexToRgba(appearance.color, 0.08);
+}
 
 // —— HELPERS ——
 
@@ -167,6 +206,7 @@ function wrapRangeWithSnippet(range, meta) {
     span.dataset.snippetId = meta.snippetId;
     span.dataset.alias     = meta.alias;
     span.style.position    = 'relative';
+    applyAppearanceToSpan(span);
 
     try {
         range.surroundContents(span);

--- a/options.html
+++ b/options.html
@@ -1,1 +1,11 @@
-<!doctype html><html><body><h3>Settings</h3><div id="settings"></div><script src="options.js"></script></body></html>
+<!doctype html>
+<html>
+  <body>
+    <h3>Appearance Settings</h3>
+    <label>Highlight Color: <input type="color" id="color"></label><br>
+    <label>Border Style: <input type="text" id="border" placeholder="2px dashed"></label><br>
+    <button id="save">Save</button>
+    <span id="status"></span>
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,22 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const colorInput = document.getElementById('color');
+  const borderInput = document.getElementById('border');
+  const status = document.getElementById('status');
+
+  chrome.storage.sync.get({ appearance: { color: '#4A90E2', border: '2px dashed' } }, data => {
+    const ap = data.appearance;
+    colorInput.value = ap.color;
+    borderInput.value = ap.border;
+  });
+
+  document.getElementById('save').addEventListener('click', () => {
+    const ap = {
+      color: colorInput.value,
+      border: borderInput.value
+    };
+    chrome.storage.sync.set({ appearance: ap }, () => {
+      status.textContent = 'Saved';
+      setTimeout(() => { status.textContent = ''; }, 1000);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- create an options page for appearance settings
- let users choose highlight color and border style
- load/sync settings via `chrome.storage.sync`
- apply appearance settings to snippets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871eac15e288321bc13a6e41100f8be