### PR TITLE
Implement sticky copy pill

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -99,6 +99,24 @@ function deserializeRange(info) {
 }
 
 // Inject a copy pill for a snippet span
+function updatePillPosition(span, pill) {
+    const rect = span.getBoundingClientRect();
+    const fullyVisible = rect.top >= 0 && rect.bottom <= window.innerHeight &&
+                         rect.left >= 0 && rect.right <= window.innerWidth;
+
+    if (fullyVisible) {
+        pill.classList.remove('fixed');
+        if (pill.parentNode !== span) {
+            span.appendChild(pill);
+        }
+    } else {
+        pill.classList.add('fixed');
+        if (pill.parentNode !== document.body) {
+            document.body.appendChild(pill);
+        }
+    }
+}
+
 function injectCopyPill(span) {
     if (!span || span.querySelector('.copy-pill')) return;
 
@@ -106,18 +124,11 @@ function injectCopyPill(span) {
     pill.className = 'copy-pill';
     pill.textContent = '⎘';
 
-    const rect = span.getBoundingClientRect();
-    const fullyVisible = rect.top >= 0 && rect.bottom <= window.innerHeight &&
-                         rect.left >= 0 && rect.right <= window.innerWidth;
+    const handler = () => updatePillPosition(span, pill);
+    window.addEventListener('scroll', handler);
+    window.addEventListener('resize', handler);
 
-    if (fullyVisible) {
-        span.appendChild(pill);
-    } else {
-        pill.style.position = 'fixed';
-        pill.style.top = '10px';
-        pill.style.right = '10px';
-        document.body.appendChild(pill);
-    }
+    updatePillPosition(span, pill);
 }
 
 // Copy snippet text to clipboard and trigger flash animation

--- a/styles.css
+++ b/styles.css
@@ -2,5 +2,6 @@
 .oneclick-snippet { border:2px dashed #4A90E2; background:rgba(74,144,226,0.08); padding:2px 4px; }
 .snippet-badge { position:absolute; top:-10px; left:0; background:#4A90E2; color:#fff; border-radius:3px; padding:2px 6px; cursor:pointer; }
 .copy-pill { position:absolute; top:0; right:0; background:#fff; border:1px solid #ccc; border-radius:12px; padding:4px 8px; cursor:pointer; box-shadow:0 2px 4px rgba(0,0,0,0.1); }
+.copy-pill.fixed { position:fixed; top:10px; right:10px; }
 @keyframes copyFlash { 0%{background:rgba(74,144,226,0.2);}50%{background:rgba(74,144,226,0.5);}100%{background:transparent;} }
 .copy-anim { animation:copyFlash .4s ease-out; }


### PR DESCRIPTION
## Summary
- keep copy button visible by moving it to the viewport when the snippet scrolls offscreen
- add fixed style class for the pill

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871ed165fdc8321820df9aee3e6bda8