### PR TITLE
Add custom hotkeys for snippets

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -8,15 +8,31 @@ const SNIPPET_BTN_ID = 'ocs-snippet-button';
 const DOC_KEY = (typeof location !== 'undefined' ? location.pathname : ''); // e.g. "/document/d/…"
 const DEFAULT_APPEARANCE = { color: '#4A90E2', border: '2px dashed' };
 let appearance = { ...DEFAULT_APPEARANCE };
+let hotkeyMap = {};
 loadAppearance(() => {
     document.querySelectorAll('.oneclick-snippet').forEach(applyAppearanceToSpan);
 });
 
 if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.onChanged) {
     chrome.storage.onChanged.addListener((changes, area) => {
-        if (area === 'sync' && changes.appearance) {
-            appearance = changes.appearance.newValue || DEFAULT_APPEARANCE;
-            document.querySelectorAll('.oneclick-snippet').forEach(applyAppearanceToSpan);
+        if (area === 'sync') {
+            if (changes.appearance) {
+                appearance = changes.appearance.newValue || DEFAULT_APPEARANCE;
+                document.querySelectorAll('.oneclick-snippet').forEach(applyAppearanceToSpan);
+            }
+            if (changes[DOC_KEY]) {
+                const arr = changes[DOC_KEY].newValue || [];
+                arr.forEach(meta => {
+                    const span = document.querySelector(`.oneclick-snippet[data-snippet-id="${meta.snippetId}"]`);
+                    if (span) {
+                        span.dataset.alias = meta.alias;
+                        span.dataset.hotkey = meta.hotkey || '';
+                        const badge = span.querySelector('.snippet-badge');
+                        if (badge) badge.textContent = meta.alias;
+                    }
+                });
+                updateHotkeyMap();
+            }
         }
     });
 }
@@ -167,6 +183,27 @@ function copySnippetText(span) {
     });
 }
 
+function hotkeyFromEvent(e) {
+    const parts = [];
+    if (e.ctrlKey) parts.push('Ctrl');
+    if (e.metaKey) parts.push('Meta');
+    if (e.altKey) parts.push('Alt');
+    if (e.shiftKey) parts.push('Shift');
+    const key = e.key.length === 1 ? e.key.toUpperCase() : e.key;
+    parts.push(key);
+    return parts.join('+');
+}
+
+function updateHotkeyMap() {
+    hotkeyMap = {};
+    document.querySelectorAll('.oneclick-snippet').forEach(span => {
+        const hk = span.dataset.hotkey;
+        if (hk) {
+            hotkeyMap[hk] = span;
+        }
+    });
+}
+
 // Update a snippet's alias in chrome.storage.sync
 function updateSnippetAlias(snippetId, alias) {
     if (typeof chrome === 'undefined' || !chrome.storage || !chrome.storage.sync) {
@@ -225,6 +262,7 @@ function wrapRangeWithSnippet(range, meta) {
     span.className = 'oneclick-snippet';
     span.dataset.snippetId = meta.snippetId;
     span.dataset.alias     = meta.alias;
+    span.dataset.hotkey    = meta.hotkey || '';
     span.style.position    = 'relative';
     applyAppearanceToSpan(span);
 
@@ -272,6 +310,7 @@ function loadSavedSnippets() {
             injectCopyPill(span);
             enableBadgeEditing(span);
         });
+        updateHotkeyMap();
     });
 }
 
@@ -326,6 +365,7 @@ function handleSnippetButtonClick() {
     };
     wrapRangeWithSnippet(range, meta);
     saveSnippetMeta(meta);
+    updateHotkeyMap();
 
     removeSnippetButton();
     sel.removeAllRanges();
@@ -510,6 +550,14 @@ if (typeof document !== 'undefined') {
             if (isEditableElement(e.target)) return;
             e.preventDefault();
             openLeaderOverlay();
+        } else {
+            if (isEditableElement(e.target)) return;
+            const hk = hotkeyFromEvent(e);
+            const span = hotkeyMap[hk];
+            if (span) {
+                e.preventDefault();
+                copySnippetText(span);
+            }
         }
     });
 }

--- a/options.html
+++ b/options.html
@@ -6,6 +6,11 @@
     <label>Border Style: <input type="text" id="border" placeholder="2px dashed"></label><br>
     <button id="save">Save</button>
     <span id="status"></span>
+
+    <h3>Snippet Hotkeys</h3>
+    <div id="snippets"></div>
+    <button id="save-hotkeys">Save Hotkeys</button>
+
     <script src="options.js"></script>
   </body>
 </html>

--- a/options.js
+++ b/options.js
@@ -2,11 +2,46 @@ document.addEventListener('DOMContentLoaded', () => {
   const colorInput = document.getElementById('color');
   const borderInput = document.getElementById('border');
   const status = document.getElementById('status');
+  const snippetsDiv = document.getElementById('snippets');
+  const hotkeyInputs = {};
+
+  function hotkeyFromEvent(e) {
+    const parts = [];
+    if (e.ctrlKey) parts.push('Ctrl');
+    if (e.metaKey) parts.push('Meta');
+    if (e.altKey) parts.push('Alt');
+    if (e.shiftKey) parts.push('Shift');
+    const key = e.key.length === 1 ? e.key.toUpperCase() : e.key;
+    parts.push(key);
+    return parts.join('+');
+  }
 
   chrome.storage.sync.get({ appearance: { color: '#4A90E2', border: '2px dashed' } }, data => {
     const ap = data.appearance;
     colorInput.value = ap.color;
     borderInput.value = ap.border;
+
+    Object.keys(data).forEach(k => {
+      if (k === 'appearance') return;
+      const arr = Array.isArray(data[k]) ? data[k] : [];
+      arr.forEach(meta => {
+        const row = document.createElement('div');
+        const label = document.createElement('label');
+        label.textContent = `${meta.alias} (${k}) `;
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.value = meta.hotkey || '';
+        input.placeholder = 'Press shortcut';
+        input.addEventListener('keydown', ev => {
+          ev.preventDefault();
+          input.value = hotkeyFromEvent(ev);
+        });
+        label.appendChild(input);
+        row.appendChild(label);
+        snippetsDiv.appendChild(row);
+        hotkeyInputs[meta.snippetId] = { input, docKey: k };
+      });
+    });
   });
 
   document.getElementById('save').addEventListener('click', () => {
@@ -19,4 +54,23 @@ document.addEventListener('DOMContentLoaded', () => {
       setTimeout(() => { status.textContent = ''; }, 1000);
     });
   });
+
+  document.getElementById('save-hotkeys').addEventListener('click', () => {
+    chrome.storage.sync.get(null, data => {
+      Object.keys(hotkeyInputs).forEach(id => {
+        const { input, docKey } = hotkeyInputs[id];
+        const arr = Array.isArray(data[docKey]) ? data[docKey] : [];
+        const idx = arr.findIndex(m => m.snippetId === id);
+        if (idx !== -1) {
+          arr[idx].hotkey = input.value.trim();
+        }
+        data[docKey] = arr;
+      });
+      chrome.storage.sync.set(data, () => {
+        status.textContent = 'Saved';
+        setTimeout(() => { status.textContent = ''; }, 1000);
+      });
+    });
+  });
 });
+


### PR DESCRIPTION
## Summary
- allow defining a hotkey per snippet through the options page
- store the hotkey with snippet metadata
- listen for configured hotkeys in the content script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687201c6aa488321af55c6067a80cdcc