### PR TITLE
Add overlay and hotkey tests

### DIFF
--- a/__tests__/overlay.test.js
+++ b/__tests__/overlay.test.js
@@ -1,0 +1,54 @@
+// Tests for overlay open/close and fuzzy search
+const cs = require('../content_script');
+const {
+  copySnippetText,
+  updateHotkeyMap,
+  closeLeaderOverlay,
+} = cs;
+
+describe('leader overlay and hotkeys', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <span class="oneclick-snippet" data-snippet-id="1" data-alias="Alpha" data-hotkey="Ctrl+Shift+A">Foo</span>
+      <span class="oneclick-snippet" data-snippet-id="2" data-alias="Beta" data-hotkey="Ctrl+Shift+B">Bar</span>
+    `;
+    global.navigator.clipboard = { writeText: jest.fn(() => Promise.resolve()) };
+    Object.defineProperty(navigator, 'platform', { value: 'Win32', configurable: true });
+    updateHotkeyMap();
+  });
+
+  afterEach(() => {
+    closeLeaderOverlay();
+  });
+
+  test('overlay opens with Ctrl+K and closes on Escape', () => {
+    const event = new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true });
+    document.dispatchEvent(event);
+    expect(document.querySelector('.ocs-overlay')).not.toBeNull();
+
+    const esc = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true });
+    document.dispatchEvent(esc);
+    expect(document.querySelector('.ocs-overlay')).toBeNull();
+  });
+
+  test('fuzzy search ranks results and copies on Enter', () => {
+    // open overlay
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }));
+    const input = document.querySelector('.ocs-overlay input');
+    expect(input).not.toBeNull();
+    // type query for Beta
+    input.value = 'Bet';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    const firstResult = document.querySelector('.ocs-results li');
+    expect(firstResult.textContent).toBe('Beta');
+    // press Enter should copy Beta span
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(global.navigator.clipboard.writeText).toHaveBeenCalledWith('Bar');
+  });
+
+  test('custom hotkey triggers copy', () => {
+    const evt = new KeyboardEvent('keydown', { key: 'A', ctrlKey: true, shiftKey: true, bubbles: true });
+    document.dispatchEvent(evt);
+    expect(global.navigator.clipboard.writeText).toHaveBeenCalledWith('Foo');
+  });
+});

--- a/content_script.js
+++ b/content_script.js
@@ -594,5 +594,16 @@ if (typeof document !== 'undefined') {
 
 // Export functions for testing in Node environments
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { serializeRange, deserializeRange, wrapRangeWithSnippet, copySnippetText };
+    module.exports = {
+        serializeRange,
+        deserializeRange,
+        wrapRangeWithSnippet,
+        copySnippetText,
+        updateHotkeyMap,
+        hotkeyFromEvent,
+        openLeaderOverlay,
+        closeLeaderOverlay,
+        searchSnippets,
+        fuzzyScore,
+    };
 }


### PR DESCRIPTION
## Summary
- export overlay/hotkey helpers from content_script.js for testing
- test overlay opening and closing
- verify fuzzy search results and snippet copying
- test custom hotkey invocation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872093f100c8321adc1d7841614958a