### PR TITLE
Add border color and animation options

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -6,7 +6,12 @@ console.log('One-Click Snippets content script loaded.');
 // CONFIG
 const SNIPPET_BTN_ID = 'ocs-snippet-button';
 const DOC_KEY = (typeof location !== 'undefined' ? location.pathname : ''); // e.g. "/document/d/…"
-const DEFAULT_APPEARANCE = { color: '#4A90E2', border: '2px dashed' };
+const DEFAULT_APPEARANCE = {
+    borderColor: '#4A90E2',
+    borderStyle: '2px dashed',
+    bgTint: 0.08,
+    animDuration: 0.4,
+};
 let appearance = { ...DEFAULT_APPEARANCE };
 let hotkeyMap = {};
 loadAppearance(() => {
@@ -17,7 +22,8 @@ if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.onChanged)
     chrome.storage.onChanged.addListener((changes, area) => {
         if (area === 'sync') {
             if (changes.appearance) {
-                appearance = changes.appearance.newValue || DEFAULT_APPEARANCE;
+                appearance = Object.assign({}, DEFAULT_APPEARANCE, changes.appearance.newValue);
+                injectAppearanceStyle();
                 document.querySelectorAll('.oneclick-snippet').forEach(applyAppearanceToSpan);
             }
             if (changes[DOC_KEY]) {
@@ -43,7 +49,8 @@ function loadAppearance(cb) {
         return;
     }
     chrome.storage.sync.get({ appearance: DEFAULT_APPEARANCE }, data => {
-        appearance = data.appearance || DEFAULT_APPEARANCE;
+        appearance = Object.assign({}, DEFAULT_APPEARANCE, data.appearance);
+        injectAppearanceStyle();
         cb && cb();
     });
 }
@@ -65,10 +72,29 @@ function hexToRgba(hex, alpha) {
     return `rgba(0,0,0,${alpha})`;
 }
 
+function injectAppearanceStyle() {
+    if (typeof document === 'undefined') return;
+    const id = 'ocs-appearance-style';
+    let style = document.getElementById(id);
+    if (!style) {
+        style = document.createElement('style');
+        style.id = id;
+        document.documentElement.appendChild(style);
+    }
+    style.textContent = `:root {\n` +
+        `  --ocs-border-style: ${appearance.borderStyle};\n` +
+        `  --ocs-border-color: ${appearance.borderColor};\n` +
+        `  --ocs-background-color: ${hexToRgba(appearance.borderColor, appearance.bgTint)};\n` +
+        `  --ocs-anim-color-start: ${hexToRgba(appearance.borderColor, 0.2)};\n` +
+        `  --ocs-anim-color-end: ${hexToRgba(appearance.borderColor, 0.5)};\n` +
+        `  --ocs-anim-duration: ${appearance.animDuration}s;\n` +
+        `}`;
+}
+
 function applyAppearanceToSpan(span) {
     if (!span) return;
-    span.style.border = `${appearance.border} ${appearance.color}`;
-    span.style.background = hexToRgba(appearance.color, 0.08);
+    span.style.border = `var(--ocs-border-style) var(--ocs-border-color)`;
+    span.style.background = `var(--ocs-background-color)`;
 }
 
 // —— HELPERS ——
@@ -325,7 +351,7 @@ function showSnippetButton(rect) {
         position: 'absolute',
         zIndex: '9999',
         padding: '4px 8px',
-        background: '#4A90E2',
+        background: 'var(--ocs-border-color)',
         color: '#fff',
         border: 'none',
         borderRadius: '4px',

--- a/options.html
+++ b/options.html
@@ -2,8 +2,10 @@
 <html>
   <body>
     <h3>Appearance Settings</h3>
-    <label>Highlight Color: <input type="color" id="color"></label><br>
-    <label>Border Style: <input type="text" id="border" placeholder="2px dashed"></label><br>
+    <label>Border Color: <input type="color" id="borderColor"></label><br>
+    <label>Border Style: <input type="text" id="borderStyle" placeholder="2px dashed"></label><br>
+    <label>Background Tint (0-1): <input type="number" id="bgTint" min="0" max="1" step="0.01"></label><br>
+    <label>Animation Duration (s): <input type="number" id="animDur" min="0" step="0.1"></label><br>
     <button id="save">Save</button>
     <span id="status"></span>
 

--- a/options.js
+++ b/options.js
@@ -1,6 +1,8 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const colorInput = document.getElementById('color');
-  const borderInput = document.getElementById('border');
+  const colorInput = document.getElementById('borderColor');
+  const borderInput = document.getElementById('borderStyle');
+  const bgTintInput = document.getElementById('bgTint');
+  const animDurInput = document.getElementById('animDur');
   const status = document.getElementById('status');
   const snippetsDiv = document.getElementById('snippets');
   const hotkeyInputs = {};
@@ -16,10 +18,12 @@ document.addEventListener('DOMContentLoaded', () => {
     return parts.join('+');
   }
 
-  chrome.storage.sync.get({ appearance: { color: '#4A90E2', border: '2px dashed' } }, data => {
+  chrome.storage.sync.get({ appearance: { borderColor: '#4A90E2', borderStyle: '2px dashed', bgTint: 0.08, animDuration: 0.4 } }, data => {
     const ap = data.appearance;
-    colorInput.value = ap.color;
-    borderInput.value = ap.border;
+    colorInput.value = ap.borderColor;
+    borderInput.value = ap.borderStyle;
+    bgTintInput.value = ap.bgTint;
+    animDurInput.value = ap.animDuration;
 
     Object.keys(data).forEach(k => {
       if (k === 'appearance') return;
@@ -46,8 +50,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
   document.getElementById('save').addEventListener('click', () => {
     const ap = {
-      color: colorInput.value,
-      border: borderInput.value
+      borderColor: colorInput.value,
+      borderStyle: borderInput.value,
+      bgTint: parseFloat(bgTintInput.value),
+      animDuration: parseFloat(animDurInput.value)
     };
     chrome.storage.sync.set({ appearance: ap }, () => {
       status.textContent = 'Saved';

--- a/styles.css
+++ b/styles.css
@@ -1,10 +1,18 @@
 /* styles.css */
-.oneclick-snippet { border:2px dashed #4A90E2; background:rgba(74,144,226,0.08); padding:2px 4px; }
-.snippet-badge { position:absolute; top:-10px; left:0; background:#4A90E2; color:#fff; border-radius:3px; padding:2px 6px; cursor:pointer; }
+:root {
+  --ocs-border-style: 2px dashed;
+  --ocs-border-color: #4A90E2;
+  --ocs-background-color: rgba(74,144,226,0.08);
+  --ocs-anim-color-start: rgba(74,144,226,0.2);
+  --ocs-anim-color-end: rgba(74,144,226,0.5);
+  --ocs-anim-duration: 0.4s;
+}
+.oneclick-snippet { border:var(--ocs-border-style) var(--ocs-border-color); background:var(--ocs-background-color); padding:2px 4px; }
+.snippet-badge { position:absolute; top:-10px; left:0; background:var(--ocs-border-color); color:#fff; border-radius:3px; padding:2px 6px; cursor:pointer; }
 .copy-pill { position:absolute; top:0; right:0; background:#fff; border:1px solid #ccc; border-radius:12px; padding:4px 8px; cursor:pointer; box-shadow:0 2px 4px rgba(0,0,0,0.1); }
 .copy-pill.fixed { position:fixed; top:10px; right:10px; }
-@keyframes copyFlash { 0%{background:rgba(74,144,226,0.2);}50%{background:rgba(74,144,226,0.5);}100%{background:transparent;} }
-.copy-anim { animation:copyFlash .4s ease-out; }
+@keyframes copyFlash { 0%{background:var(--ocs-anim-color-start);}50%{background:var(--ocs-anim-color-end);}100%{background:transparent;} }
+.copy-anim { animation:copyFlash var(--ocs-anim-duration) ease-out; }
 
 /* Leader key overlay */
 .ocs-overlay {


### PR DESCRIPTION
## Summary
- add new appearance settings in options
- support border color, background tint and animation duration
- inject CSS variables for appearance

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68720c0a2ce083218c2ea01234da2652