### PR TITLE
Refactor content script into modules

### DIFF
--- a/__tests__/copySnippet.test.js
+++ b/__tests__/copySnippet.test.js
@@ -1,4 +1,4 @@
-const { copySnippetText } = require('../content_script');
+const { copySnippetText } = require('../modules/dom');
 
 describe('copySnippetText', () => {
   beforeEach(() => {

--- a/__tests__/overlay.test.js
+++ b/__tests__/overlay.test.js
@@ -1,10 +1,12 @@
 // Tests for overlay open/close and fuzzy search
-const cs = require('../content_script');
+// load modules so globals exist before content_script
+require('../modules/selection');
+const { copySnippetText } = require('../modules/dom');
+const storage = require('../modules/storage');
 const {
-  copySnippetText,
   updateHotkeyMap,
   closeLeaderOverlay,
-} = cs;
+} = require('../content_script');
 
 describe('leader overlay and hotkeys', () => {
   beforeEach(() => {

--- a/__tests__/serialization.test.js
+++ b/__tests__/serialization.test.js
@@ -1,4 +1,4 @@
-const { serializeRange, deserializeRange } = require('../content_script');
+const { serializeRange, deserializeRange } = require('../modules/selection');
 
 describe('range serialization', () => {
   beforeEach(() => {

--- a/__tests__/storage.test.js
+++ b/__tests__/storage.test.js
@@ -1,0 +1,21 @@
+const { saveSnippetMeta } = require('../modules/storage');
+
+describe('saveSnippetMeta', () => {
+  beforeEach(() => {
+    global.chrome = {
+      storage: {
+        sync: {
+          get: jest.fn((keys, cb) => cb({ [global.location.pathname]: [] })),
+          set: jest.fn()
+        }
+      }
+    };
+  });
+
+  test('stores snippet metadata', () => {
+    const meta = { snippetId: '1' };
+    saveSnippetMeta(meta);
+    expect(chrome.storage.sync.get).toHaveBeenCalled();
+    expect(chrome.storage.sync.set).toHaveBeenCalledWith({ [global.location.pathname]: [meta] });
+  });
+});

--- a/__tests__/wrapSnippet.test.js
+++ b/__tests__/wrapSnippet.test.js
@@ -1,4 +1,4 @@
-const { wrapRangeWithSnippet } = require('../content_script');
+const { wrapRangeWithSnippet } = require('../modules/selection');
 
 describe('wrapRangeWithSnippet', () => {
   beforeEach(() => {

--- a/content_script.js
+++ b/content_script.js
@@ -3,16 +3,6 @@
 
 console.log('One-Click Snippets content script loaded.');
 
-// CONFIG
-const SNIPPET_BTN_ID = 'ocs-snippet-button';
-const DOC_KEY = (typeof location !== 'undefined' ? location.pathname : ''); // e.g. "/document/d/…"
-const DEFAULT_APPEARANCE = {
-    borderColor: '#4A90E2',
-    borderStyle: '2px dashed',
-    bgTint: 0.08,
-    animDuration: 0.4,
-};
-let appearance = { ...DEFAULT_APPEARANCE };
 let hotkeyMap = {};
 loadAppearance(() => {
     document.querySelectorAll('.oneclick-snippet').forEach(applyAppearanceToSpan);
@@ -43,362 +33,6 @@ if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.onChanged)
     });
 }
 
-function loadAppearance(cb) {
-    if (typeof chrome === 'undefined' || !chrome.storage || !chrome.storage.sync) {
-        cb && cb();
-        return;
-    }
-    chrome.storage.sync.get({ appearance: DEFAULT_APPEARANCE }, data => {
-        appearance = Object.assign({}, DEFAULT_APPEARANCE, data.appearance);
-        injectAppearanceStyle();
-        cb && cb();
-    });
-}
-
-function hexToRgba(hex, alpha) {
-    hex = hex.replace('#','');
-    if (hex.length === 3) {
-        const r = parseInt(hex[0] + hex[0], 16);
-        const g = parseInt(hex[1] + hex[1], 16);
-        const b = parseInt(hex[2] + hex[2], 16);
-        return `rgba(${r},${g},${b},${alpha})`;
-    } else if (hex.length === 6) {
-        const bigint = parseInt(hex, 16);
-        const r = (bigint >> 16) & 255;
-        const g = (bigint >> 8) & 255;
-        const b = bigint & 255;
-        return `rgba(${r},${g},${b},${alpha})`;
-    }
-    return `rgba(0,0,0,${alpha})`;
-}
-
-function injectAppearanceStyle() {
-    if (typeof document === 'undefined') return;
-    const id = 'ocs-appearance-style';
-    let style = document.getElementById(id);
-    if (!style) {
-        style = document.createElement('style');
-        style.id = id;
-        document.documentElement.appendChild(style);
-    }
-    style.textContent = `:root {\n` +
-        `  --ocs-border-style: ${appearance.borderStyle};\n` +
-        `  --ocs-border-color: ${appearance.borderColor};\n` +
-        `  --ocs-background-color: ${hexToRgba(appearance.borderColor, appearance.bgTint)};\n` +
-        `  --ocs-anim-color-start: ${hexToRgba(appearance.borderColor, 0.2)};\n` +
-        `  --ocs-anim-color-end: ${hexToRgba(appearance.borderColor, 0.5)};\n` +
-        `  --ocs-anim-duration: ${appearance.animDuration}s;\n` +
-        `}`;
-}
-
-function applyAppearanceToSpan(span) {
-    if (!span) return;
-    span.style.border = `var(--ocs-border-style) var(--ocs-border-color)`;
-    span.style.background = `var(--ocs-background-color)`;
-}
-
-// —— HELPERS ——
-
-// Remove any existing “+ Snippet” button
-function removeSnippetButton() {
-    const btn = document.getElementById(SNIPPET_BTN_ID);
-    if (btn) btn.remove();
-}
-
-// Serialize a node’s path (array of child-indices from document)
-function serializeNodePath(node) {
-    const path = [];
-    let cur = node;
-    while (cur && cur !== document) {
-        const parent = cur.parentNode;
-        if (!parent) break;
-        path.unshift(Array.prototype.indexOf.call(parent.childNodes, cur));
-        cur = parent;
-    }
-    return path;
-}
-
-// Deserialize that path back to a DOM node
-function deserializeNodePath(path) {
-    let cur = document;
-    for (const idx of path) {
-        if (!cur.childNodes[idx]) return null;
-        cur = cur.childNodes[idx];
-    }
-    return cur;
-}
-
-// Convert a Range → JSON-friendly info
-function serializeRange(range) {
-    return {
-        startPath: serializeNodePath(range.startContainer),
-        startOffset: range.startOffset,
-        endPath: serializeNodePath(range.endContainer),
-        endOffset: range.endOffset
-    };
-}
-
-// Convert that info back to a Range
-function deserializeRange(info) {
-    const startNode = deserializeNodePath(info.startPath);
-    const endNode   = deserializeNodePath(info.endPath);
-    if (!startNode || !endNode) return null;
-    const range = document.createRange();
-    range.setStart(startNode, info.startOffset);
-    range.setEnd(endNode, info.endOffset);
-    return range;
-}
-
-// Inject a copy pill for a snippet span
-function updatePillPosition(span, pill) {
-    const rect = span.getBoundingClientRect();
-    const fullyVisible = rect.top >= 0 && rect.bottom <= window.innerHeight &&
-                         rect.left >= 0 && rect.right <= window.innerWidth;
-
-    if (fullyVisible) {
-        pill.classList.remove('fixed');
-        if (pill.parentNode !== span) {
-            span.appendChild(pill);
-        }
-    } else {
-        pill.classList.add('fixed');
-        if (pill.parentNode !== document.body) {
-            document.body.appendChild(pill);
-        }
-    }
-}
-
-function injectCopyPill(span) {
-    if (!span || span.querySelector('.copy-pill')) return;
-
-    const pill = document.createElement('button');
-    pill.className = 'copy-pill';
-    pill.textContent = '⎘';
-
-    const handler = () => updatePillPosition(span, pill);
-    window.addEventListener('scroll', handler);
-    window.addEventListener('resize', handler);
-
-    updatePillPosition(span, pill);
-}
-
-// Copy snippet text to clipboard and trigger flash animation
-function copySnippetText(span) {
-    if (!span) return;
-    const text = span.innerText || span.textContent || '';
-    const doCopy = navigator.clipboard && navigator.clipboard.writeText ?
-        navigator.clipboard.writeText(text) :
-        new Promise(resolve => {
-            const ta = document.createElement('textarea');
-            ta.value = text;
-            ta.style.position = 'fixed';
-            ta.style.top = '-9999px';
-            document.body.appendChild(ta);
-            ta.focus();
-            ta.select();
-            try { document.execCommand('copy'); } catch (e) { /* noop */ }
-            document.body.removeChild(ta);
-            resolve();
-        });
-
-    doCopy.then(() => {
-        span.classList.add('copy-anim');
-        span.addEventListener('animationend', () => {
-        span.classList.remove('copy-anim');
-    }, { once: true });
-});
-}
-
-// Show a temporary on-screen message
-function showMessage(msg, timeout = 4000) {
-    if (typeof document === 'undefined') return;
-    const div = document.createElement('div');
-    div.className = 'ocs-message';
-    div.textContent = msg;
-    Object.assign(div.style, {
-        position: 'fixed',
-        bottom: '10px',
-        right: '10px',
-        background: '#333',
-        color: '#fff',
-        padding: '8px 12px',
-        borderRadius: '4px',
-        fontSize: '12px',
-        zIndex: '10000',
-        opacity: '0.9'
-    });
-    document.body.appendChild(div);
-    setTimeout(() => div.remove(), timeout);
-}
-
-function hotkeyFromEvent(e) {
-    const parts = [];
-    if (e.ctrlKey) parts.push('Ctrl');
-    if (e.metaKey) parts.push('Meta');
-    if (e.altKey) parts.push('Alt');
-    if (e.shiftKey) parts.push('Shift');
-    const key = e.key.length === 1 ? e.key.toUpperCase() : e.key;
-    parts.push(key);
-    return parts.join('+');
-}
-
-function updateHotkeyMap() {
-    hotkeyMap = {};
-    document.querySelectorAll('.oneclick-snippet').forEach(span => {
-        const hk = span.dataset.hotkey;
-        if (hk) {
-            hotkeyMap[hk] = span;
-        }
-    });
-}
-
-// Update a snippet's alias in chrome.storage.sync
-function updateSnippetAlias(snippetId, alias) {
-    if (typeof chrome === 'undefined' || !chrome.storage || !chrome.storage.sync) {
-        return;
-    }
-    chrome.storage.sync.get([DOC_KEY], data => {
-        const arr = data[DOC_KEY] || [];
-        const idx = arr.findIndex(m => m.snippetId === snippetId);
-        if (idx !== -1) {
-            arr[idx].alias = alias;
-            chrome.storage.sync.set({ [DOC_KEY]: arr });
-        }
-    });
-}
-
-// Enable inline renaming of a snippet badge
-function enableBadgeEditing(span) {
-    const badge = span.querySelector('.snippet-badge');
-    if (!badge) return;
-    badge.addEventListener('dblclick', () => {
-        const current = badge.textContent;
-        const input = document.createElement('input');
-        input.type = 'text';
-        input.value = current;
-        input.style.minWidth = '40px';
-        badge.replaceWith(input);
-        input.focus();
-        input.select();
-
-        const finish = (save) => {
-            if (save) {
-                const alias = input.value.trim() || current;
-                badge.textContent = alias;
-                span.dataset.alias = alias;
-                updateSnippetAlias(span.dataset.snippetId, alias);
-            }
-            input.replaceWith(badge);
-        };
-
-        input.addEventListener('blur', () => finish(true));
-        input.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter') {
-                e.preventDefault();
-                finish(true);
-            } else if (e.key === 'Escape') {
-                finish(false);
-            }
-        });
-    });
-}
-
-// Wrap a Range in a span + inject its badge
-function wrapRangeWithSnippet(range, meta) {
-    if (!range) return;
-    const span = document.createElement('span');
-    span.className = 'oneclick-snippet';
-    span.dataset.snippetId = meta.snippetId;
-    span.dataset.alias     = meta.alias;
-    span.dataset.hotkey    = meta.hotkey || '';
-    span.style.position    = 'relative';
-    applyAppearanceToSpan(span);
-
-    try {
-        range.surroundContents(span);
-    } catch (e) {
-        console.error('Could not surround contents:', e);
-        return;
-    }
-
-    // Badge
-    const badge = document.createElement('div');
-    badge.className = 'snippet-badge';
-    badge.textContent = meta.alias;
-    span.insertBefore(badge, span.firstChild);
-
-    injectCopyPill(span);
-    enableBadgeEditing(span);
-}
-
-// Save a snippet’s metadata to chrome.storage.sync
-function saveSnippetMeta(meta) {
-    if (typeof chrome === 'undefined' || !chrome.storage || !chrome.storage.sync) {
-        return;
-    }
-    chrome.storage.sync.get([DOC_KEY], data => {
-        const arr = data[DOC_KEY] || [];
-        arr.push(meta);
-        chrome.storage.sync.set({ [DOC_KEY]: arr });
-    });
-}
-
-// Load & rehydrate all snippets for this doc
-function loadSavedSnippets() {
-    if (typeof chrome === 'undefined' || !chrome.storage || !chrome.storage.sync) {
-        return;
-    }
-    chrome.storage.sync.get([DOC_KEY], data => {
-        const arr = data[DOC_KEY] || [];
-        let failed = 0;
-        arr.forEach(meta => {
-            const range = deserializeRange(meta.rangeInfo);
-            if (!range) {
-                console.warn('One-Click Snippets: could not restore snippet', meta);
-                failed++;
-                return;
-            }
-            wrapRangeWithSnippet(range, meta);
-        });
-        document.querySelectorAll('.oneclick-snippet').forEach(span => {
-            injectCopyPill(span);
-            enableBadgeEditing(span);
-        });
-        updateHotkeyMap();
-        if (failed > 0) {
-            showMessage(`${failed} snippet${failed === 1 ? '' : 's'} could not be restored. They may have been edited or removed.`);
-        }
-    });
-}
-
-// Position and show the “+ Snippet” pill
-function showSnippetButton(rect) {
-    removeSnippetButton();
-
-    const btn = document.createElement('button');
-    btn.id = SNIPPET_BTN_ID;
-    btn.textContent = '+ Snippet';
-    Object.assign(btn.style, {
-        position: 'absolute',
-        zIndex: '9999',
-        padding: '4px 8px',
-        background: 'var(--ocs-border-color)',
-        color: '#fff',
-        border: 'none',
-        borderRadius: '4px',
-        fontSize: '12px',
-        cursor: 'pointer'
-    });
-
-    const top  = rect.top  + window.scrollY - 30;
-    const left = rect.left + window.scrollX;
-    btn.style.top  = `${top}px`;
-    btn.style.left = `${left}px`;
-
-    document.body.appendChild(btn);
-}
-
-// Handle click on the “+ Snippet” button
 function handleSnippetButtonClick() {
     const sel = window.getSelection();
     if (!sel || sel.isCollapsed || sel.rangeCount === 0) {
@@ -422,10 +56,32 @@ function handleSnippetButtonClick() {
     };
     wrapRangeWithSnippet(range, meta);
     saveSnippetMeta(meta);
+
     updateHotkeyMap();
 
     removeSnippetButton();
     sel.removeAllRanges();
+}
+
+function hotkeyFromEvent(e) {
+    const parts = [];
+    if (e.ctrlKey) parts.push('Ctrl');
+    if (e.metaKey) parts.push('Meta');
+    if (e.altKey) parts.push('Alt');
+    if (e.shiftKey) parts.push('Shift');
+    const key = e.key.length === 1 ? e.key.toUpperCase() : e.key;
+    parts.push(key);
+    return parts.join('+');
+}
+
+function updateHotkeyMap() {
+    hotkeyMap = {};
+    document.querySelectorAll('.oneclick-snippet').forEach(span => {
+        const hk = span.dataset.hotkey;
+        if (hk) {
+            hotkeyMap[hk] = span;
+        }
+    });
 }
 
 // —— EVENT WIRES ——
@@ -651,11 +307,13 @@ if (typeof document !== 'undefined') {
 
 // Export functions for testing in Node environments
 if (typeof module !== 'undefined' && module.exports) {
+    const dom = require('./modules/dom');
+    const selection = require('./modules/selection');
+    const storage = require('./modules/storage');
     module.exports = {
-        serializeRange,
-        deserializeRange,
-        wrapRangeWithSnippet,
-        copySnippetText,
+        ...dom,
+        ...selection,
+        ...storage,
         updateHotkeyMap,
         hotkeyFromEvent,
         openLeaderOverlay,

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,12 @@
   "content_scripts": [
     {
       "matches": [ "https://docs.google.com/document/*" ],
-      "js": [ "content_script.js" ],
+      "js": [
+        "modules/selection.js",
+        "modules/dom.js",
+        "modules/storage.js",
+        "content_script.js"
+      ],
       "css": [ "styles.css" ]
     }
   ]

--- a/modules/dom.js
+++ b/modules/dom.js
@@ -1,0 +1,211 @@
+(function(global){
+    const SNIPPET_BTN_ID = 'ocs-snippet-button';
+
+    function hexToRgba(hex, alpha) {
+        hex = hex.replace('#','');
+        if (hex.length === 3) {
+            const r = parseInt(hex[0] + hex[0], 16);
+            const g = parseInt(hex[1] + hex[1], 16);
+            const b = parseInt(hex[2] + hex[2], 16);
+            return `rgba(${r},${g},${b},${alpha})`;
+        } else if (hex.length === 6) {
+            const bigint = parseInt(hex, 16);
+            const r = (bigint >> 16) & 255;
+            const g = (bigint >> 8) & 255;
+            const b = bigint & 255;
+            return `rgba(${r},${g},${b},${alpha})`;
+        }
+        return `rgba(0,0,0,${alpha})`;
+    }
+
+    function injectAppearanceStyle() {
+        if (typeof document === 'undefined') return;
+        const id = 'ocs-appearance-style';
+        let style = document.getElementById(id);
+        if (!style) {
+            style = document.createElement('style');
+            style.id = id;
+            document.documentElement.appendChild(style);
+        }
+        const app = typeof appearance !== 'undefined' ? appearance : {};
+        style.textContent = `:root {\n` +
+            `  --ocs-border-style: ${app.borderStyle};\n` +
+            `  --ocs-border-color: ${app.borderColor};\n` +
+            `  --ocs-background-color: ${hexToRgba(app.borderColor, app.bgTint)};\n` +
+            `  --ocs-anim-color-start: ${hexToRgba(app.borderColor, 0.2)};\n` +
+            `  --ocs-anim-color-end: ${hexToRgba(app.borderColor, 0.5)};\n` +
+            `  --ocs-anim-duration: ${app.animDuration}s;\n` +
+            `}`;
+    }
+
+    function applyAppearanceToSpan(span) {
+        if (!span) return;
+        span.style.border = `var(--ocs-border-style) var(--ocs-border-color)`;
+        span.style.background = `var(--ocs-background-color)`;
+    }
+
+    function removeSnippetButton() {
+        const btn = document.getElementById(SNIPPET_BTN_ID);
+        if (btn) btn.remove();
+    }
+
+    function updatePillPosition(span, pill) {
+        const rect = span.getBoundingClientRect();
+        const fullyVisible = rect.top >= 0 && rect.bottom <= window.innerHeight &&
+                             rect.left >= 0 && rect.right <= window.innerWidth;
+        if (fullyVisible) {
+            pill.classList.remove('fixed');
+            if (pill.parentNode !== span) {
+                span.appendChild(pill);
+            }
+        } else {
+            pill.classList.add('fixed');
+            if (pill.parentNode !== document.body) {
+                document.body.appendChild(pill);
+            }
+        }
+    }
+
+    function injectCopyPill(span) {
+        if (!span || span.querySelector('.copy-pill')) return;
+        const pill = document.createElement('button');
+        pill.className = 'copy-pill';
+        pill.textContent = '⎘';
+        const handler = () => updatePillPosition(span, pill);
+        window.addEventListener('scroll', handler);
+        window.addEventListener('resize', handler);
+        updatePillPosition(span, pill);
+    }
+
+    function copySnippetText(span) {
+        if (!span) return;
+        const text = span.innerText || span.textContent || '';
+        const doCopy = navigator.clipboard && navigator.clipboard.writeText ?
+            navigator.clipboard.writeText(text) :
+            new Promise(resolve => {
+                const ta = document.createElement('textarea');
+                ta.value = text;
+                ta.style.position = 'fixed';
+                ta.style.top = '-9999px';
+                document.body.appendChild(ta);
+                ta.focus();
+                ta.select();
+                try { document.execCommand('copy'); } catch (e) { /* noop */ }
+                document.body.removeChild(ta);
+                resolve();
+            });
+        doCopy.then(() => {
+            span.classList.add('copy-anim');
+            span.addEventListener('animationend', () => {
+                span.classList.remove('copy-anim');
+            }, { once: true });
+        });
+    }
+
+    function showMessage(msg, timeout = 4000) {
+        if (typeof document === 'undefined') return;
+        const div = document.createElement('div');
+        div.className = 'ocs-message';
+        div.textContent = msg;
+        Object.assign(div.style, {
+            position: 'fixed',
+            bottom: '10px',
+            right: '10px',
+            background: '#333',
+            color: '#fff',
+            padding: '8px 12px',
+            borderRadius: '4px',
+            fontSize: '12px',
+            zIndex: '10000',
+            opacity: '0.9'
+        });
+        document.body.appendChild(div);
+        setTimeout(() => div.remove(), timeout);
+    }
+
+    function showSnippetButton(rect) {
+        removeSnippetButton();
+        const btn = document.createElement('button');
+        btn.id = SNIPPET_BTN_ID;
+        btn.textContent = '+ Snippet';
+        Object.assign(btn.style, {
+            position: 'absolute',
+            zIndex: '9999',
+            padding: '4px 8px',
+            background: 'var(--ocs-border-color)',
+            color: '#fff',
+            border: 'none',
+            borderRadius: '4px',
+            fontSize: '12px',
+            cursor: 'pointer'
+        });
+        const top  = rect.top  + window.scrollY - 30;
+        const left = rect.left + window.scrollX;
+        btn.style.top  = `${top}px`;
+        btn.style.left = `${left}px`;
+        document.body.appendChild(btn);
+    }
+
+    global.SNIPPET_BTN_ID = SNIPPET_BTN_ID;
+    function enableBadgeEditing(span) {
+        const badge = span.querySelector('.snippet-badge');
+        if (!badge) return;
+        badge.addEventListener('dblclick', () => {
+            const current = badge.textContent;
+            const input = document.createElement('input');
+            input.type = 'text';
+            input.value = current;
+            input.style.minWidth = '40px';
+            badge.replaceWith(input);
+            input.focus();
+            input.select();
+            const finish = (save) => {
+                if (save) {
+                    const alias = input.value.trim() || current;
+                    badge.textContent = alias;
+                    span.dataset.alias = alias;
+                    if (typeof updateSnippetAlias === 'function') {
+                        updateSnippetAlias(span.dataset.snippetId, alias);
+                    }
+                }
+                input.replaceWith(badge);
+            };
+            input.addEventListener('blur', () => finish(true));
+            input.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    finish(true);
+                } else if (e.key === 'Escape') {
+                    finish(false);
+                }
+            });
+        });
+    }
+    global.SNIPPET_BTN_ID = SNIPPET_BTN_ID;
+    global.hexToRgba = hexToRgba;
+    global.injectAppearanceStyle = injectAppearanceStyle;
+    global.applyAppearanceToSpan = applyAppearanceToSpan;
+    global.removeSnippetButton = removeSnippetButton;
+    global.updatePillPosition = updatePillPosition;
+    global.injectCopyPill = injectCopyPill;
+    global.copySnippetText = copySnippetText;
+    global.showMessage = showMessage;
+    global.showSnippetButton = showSnippetButton;
+    global.enableBadgeEditing = enableBadgeEditing;
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = {
+            SNIPPET_BTN_ID,
+            hexToRgba,
+            injectAppearanceStyle,
+            applyAppearanceToSpan,
+            removeSnippetButton,
+            updatePillPosition,
+            injectCopyPill,
+            copySnippetText,
+            showMessage,
+            showSnippetButton,
+            enableBadgeEditing,
+        };
+    }
+})(typeof window !== "undefined" ? window : global);

--- a/modules/selection.js
+++ b/modules/selection.js
@@ -1,0 +1,80 @@
+(function(global){
+    function serializeNodePath(node) {
+        const path = [];
+        let cur = node;
+        while (cur && cur !== document) {
+            const parent = cur.parentNode;
+            if (!parent) break;
+            path.unshift(Array.prototype.indexOf.call(parent.childNodes, cur));
+            cur = parent;
+        }
+        return path;
+    }
+
+    function deserializeNodePath(path) {
+        let cur = document;
+        for (const idx of path) {
+            if (!cur.childNodes[idx]) return null;
+            cur = cur.childNodes[idx];
+        }
+        return cur;
+    }
+
+    function serializeRange(range) {
+        return {
+            startPath: serializeNodePath(range.startContainer),
+            startOffset: range.startOffset,
+            endPath: serializeNodePath(range.endContainer),
+            endOffset: range.endOffset
+        };
+    }
+
+    function deserializeRange(info) {
+        const startNode = deserializeNodePath(info.startPath);
+        const endNode   = deserializeNodePath(info.endPath);
+        if (!startNode || !endNode) return null;
+        const range = document.createRange();
+        range.setStart(startNode, info.startOffset);
+        range.setEnd(endNode, info.endOffset);
+        return range;
+    }
+
+    function wrapRangeWithSnippet(range, meta) {
+        if (!range) return;
+        const span = document.createElement('span');
+        span.className = 'oneclick-snippet';
+        span.dataset.snippetId = meta.snippetId;
+        span.dataset.alias     = meta.alias;
+        span.dataset.hotkey    = meta.hotkey || '';
+        span.style.position    = 'relative';
+        if (typeof applyAppearanceToSpan === 'function') applyAppearanceToSpan(span);
+        try {
+            range.surroundContents(span);
+        } catch (e) {
+            console.error('Could not surround contents:', e);
+            return;
+        }
+        const badge = document.createElement('div');
+        badge.className = 'snippet-badge';
+        badge.textContent = meta.alias;
+        span.insertBefore(badge, span.firstChild);
+        if (typeof injectCopyPill === 'function') injectCopyPill(span);
+        if (typeof enableBadgeEditing === 'function') enableBadgeEditing(span);
+    }
+
+    global.serializeNodePath = serializeNodePath;
+    global.deserializeNodePath = deserializeNodePath;
+    global.serializeRange = serializeRange;
+    global.deserializeRange = deserializeRange;
+    global.wrapRangeWithSnippet = wrapRangeWithSnippet;
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = {
+            serializeNodePath,
+            deserializeNodePath,
+            serializeRange,
+            deserializeRange,
+            wrapRangeWithSnippet,
+        };
+    }
+})(typeof window !== 'undefined' ? window : global);

--- a/modules/storage.js
+++ b/modules/storage.js
@@ -1,0 +1,93 @@
+(function(global){
+    const DOC_KEY = (typeof location !== 'undefined' ? location.pathname : '');
+    const DEFAULT_APPEARANCE = {
+        borderColor: '#4A90E2',
+        borderStyle: '2px dashed',
+        bgTint: 0.08,
+        animDuration: 0.4,
+    };
+    global.DEFAULT_APPEARANCE = DEFAULT_APPEARANCE;
+    let appearance = { ...DEFAULT_APPEARANCE };
+    global.appearance = appearance;
+
+    function loadAppearance(cb) {
+        if (typeof chrome === 'undefined' || !chrome.storage || !chrome.storage.sync) {
+            cb && cb();
+            return;
+        }
+        chrome.storage.sync.get({ appearance: DEFAULT_APPEARANCE }, data => {
+            appearance = Object.assign({}, DEFAULT_APPEARANCE, data.appearance);
+            global.appearance = appearance;
+            if (typeof injectAppearanceStyle === 'function') injectAppearanceStyle();
+            cb && cb();
+        });
+    }
+
+    function saveSnippetMeta(meta) {
+        if (typeof chrome === 'undefined' || !chrome.storage || !chrome.storage.sync) {
+            return;
+        }
+        chrome.storage.sync.get([DOC_KEY], data => {
+            const arr = data[DOC_KEY] || [];
+            arr.push(meta);
+            chrome.storage.sync.set({ [DOC_KEY]: arr });
+        });
+    }
+
+    function loadSavedSnippets() {
+        if (typeof chrome === 'undefined' || !chrome.storage || !chrome.storage.sync) {
+            return;
+        }
+        chrome.storage.sync.get([DOC_KEY], data => {
+            const arr = data[DOC_KEY] || [];
+            let failed = 0;
+            arr.forEach(meta => {
+                const range = typeof deserializeRange === 'function' ? deserializeRange(meta.rangeInfo) : null;
+                if (!range) {
+                    console.warn('One-Click Snippets: could not restore snippet', meta);
+                    failed++;
+                    return;
+                }
+                if (typeof wrapRangeWithSnippet === 'function') wrapRangeWithSnippet(range, meta);
+            });
+            document.querySelectorAll('.oneclick-snippet').forEach(span => {
+                if (typeof injectCopyPill === 'function') injectCopyPill(span);
+                if (typeof enableBadgeEditing === 'function') enableBadgeEditing(span);
+            });
+            if (typeof updateHotkeyMap === 'function') updateHotkeyMap();
+            if (failed > 0 && typeof showMessage === 'function') {
+                showMessage(`${failed} snippet${failed === 1 ? '' : 's'} could not be restored. They may have been edited or removed.`);
+            }
+        });
+    }
+
+    function updateSnippetAlias(snippetId, alias) {
+        if (typeof chrome === 'undefined' || !chrome.storage || !chrome.storage.sync) {
+            return;
+        }
+        chrome.storage.sync.get([DOC_KEY], data => {
+            const arr = data[DOC_KEY] || [];
+            const idx = arr.findIndex(m => m.snippetId === snippetId);
+            if (idx !== -1) {
+                arr[idx].alias = alias;
+                chrome.storage.sync.set({ [DOC_KEY]: arr });
+            }
+        });
+    }
+
+    global.DOC_KEY = DOC_KEY;
+    global.loadAppearance = loadAppearance;
+    global.saveSnippetMeta = saveSnippetMeta;
+    global.loadSavedSnippets = loadSavedSnippets;
+    global.updateSnippetAlias = updateSnippetAlias;
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = {
+            loadAppearance,
+            saveSnippetMeta,
+            loadSavedSnippets,
+            updateSnippetAlias,
+            DEFAULT_APPEARANCE,
+        };
+    }
+})(typeof window !== 'undefined' ? window : global);


### PR DESCRIPTION
## Summary
- split large content script into `modules/` for selection, DOM, and storage logic
- update manifest to load new modules
- adjust content script to use global helpers and export modules for tests
- update existing tests and add storage tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687210a92b8c8321880a3f30f0877095