### PR TITLE
Improve extension UI and add welcome popup

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -217,6 +217,11 @@ function openLeaderOverlay() {
     modal.className = 'ocs-modal';
     modal.setAttribute('role', 'dialog');
     modal.setAttribute('aria-modal', 'true');
+    const closeBtn = document.createElement('button');
+    closeBtn.className = 'close-btn';
+    closeBtn.innerHTML = '&times;';
+    closeBtn.addEventListener('click', closeLeaderOverlay);
+    modal.appendChild(closeBtn);
     const input = document.createElement('input');
     input.type = 'text';
     input.setAttribute('aria-controls', 'ocs-results');

--- a/options.html
+++ b/options.html
@@ -1,18 +1,30 @@
 <!doctype html>
 <html>
-  <body>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body class="ocs-ui">
+  <header>
+    <img src="icons/icon48.png" class="logo" alt="Logo">
+    <h2>Options</h2>
+  </header>
+  <section>
     <h3>Appearance Settings</h3>
-    <label>Border Color: <input type="color" id="borderColor"></label><br>
-    <label>Border Style: <input type="text" id="borderStyle" placeholder="2px dashed"></label><br>
-    <label>Background Tint (0-1): <input type="number" id="bgTint" min="0" max="1" step="0.01"></label><br>
-    <label>Animation Duration (s): <input type="number" id="animDur" min="0" step="0.1"></label><br>
-    <button id="save">Save</button>
-    <span id="status"></span>
+    <div class="form-row"><label>Border Color: <input type="color" id="borderColor"></label></div>
+    <div class="form-row"><label>Border Style: <input type="text" id="borderStyle" placeholder="2px dashed"></label></div>
+    <div class="form-row"><label>Background Tint (0-1): <input type="number" id="bgTint" min="0" max="1" step="0.01"></label></div>
+    <div class="form-row"><label>Animation Duration (s): <input type="number" id="animDur" min="0" step="0.1"></label></div>
+    <button id="save">Save</button> <span id="status"></span>
+  </section>
 
+  <section>
     <h3>Snippet Hotkeys</h3>
     <div id="snippets"></div>
     <button id="save-hotkeys">Save Hotkeys</button>
+  </section>
 
-    <script src="options.js"></script>
-  </body>
+  <script src="options.js"></script>
+</body>
 </html>

--- a/popup.html
+++ b/popup.html
@@ -1,1 +1,20 @@
-<!doctype html><html><body><h3>One-Click Snippets</h3><div id="list"></div><script src="popup.js"></script></body></html>
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body class="ocs-ui">
+  <header>
+    <img src="icons/icon48.png" class="logo" alt="Logo">
+    <h2>Snippets</h2>
+  </header>
+  <div id="guide" style="display:none">
+    <p>Highlight text in Google Docs and click <strong>+ Snippet</strong>. Use <kbd>Ctrl+K</kbd> to search.</p>
+    <button id="close-guide">Got it!</button>
+  </div>
+  <div id="list"></div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,51 @@
+
+document.addEventListener('DOMContentLoaded', () => {
+  const listEl = document.getElementById('list');
+  const guide = document.getElementById('guide');
+  const closeGuideBtn = document.getElementById('close-guide');
+
+  function renderSnippets(docKey) {
+    chrome.storage.sync.get([docKey], data => {
+      const arr = data[docKey] || [];
+      listEl.innerHTML = '';
+      arr.forEach(meta => {
+        const row = document.createElement('div');
+        row.className = 'snippet-row';
+        const name = document.createElement('span');
+        name.textContent = meta.alias;
+        row.appendChild(name);
+        if (meta.hotkey) {
+          const hk = document.createElement('span');
+          hk.className = 'hotkey';
+          hk.textContent = meta.hotkey;
+          row.appendChild(hk);
+        }
+        listEl.appendChild(row);
+      });
+    });
+  }
+
+  function loadForActiveTab() {
+    chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+      const tab = tabs[0];
+      if (!tab) return;
+      try {
+        const docKey = new URL(tab.url).pathname;
+        renderSnippets(docKey);
+      } catch (e) {}
+    });
+  }
+
+  chrome.storage.sync.get({ hasSeenGuide: false }, result => {
+    if (!result.hasSeenGuide) {
+      guide.style.display = 'block';
+      closeGuideBtn.addEventListener('click', () => {
+        guide.style.display = 'none';
+        chrome.storage.sync.set({ hasSeenGuide: true });
+        loadForActiveTab();
+      });
+    } else {
+      loadForActiveTab();
+    }
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -6,10 +6,11 @@
   --ocs-anim-color-start: rgba(74,144,226,0.2);
   --ocs-anim-color-end: rgba(74,144,226,0.5);
   --ocs-anim-duration: 0.4s;
+  --ocs-font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
 }
-.oneclick-snippet { border:var(--ocs-border-style) var(--ocs-border-color); background:var(--ocs-background-color); padding:2px 4px; }
-.snippet-badge { position:absolute; top:-10px; left:0; background:var(--ocs-border-color); color:#fff; border-radius:3px; padding:2px 6px; cursor:pointer; }
-.copy-pill { position:absolute; top:0; right:0; background:#fff; border:1px solid #ccc; border-radius:12px; padding:4px 8px; cursor:pointer; box-shadow:0 2px 4px rgba(0,0,0,0.1); }
+.oneclick-snippet { border:var(--ocs-border-style) var(--ocs-border-color); background:var(--ocs-background-color); padding:2px 4px; font-family: var(--ocs-font-family); }
+.snippet-badge { position:absolute; top:-10px; left:0; background:var(--ocs-border-color); color:#fff; border-radius:3px; padding:2px 6px; cursor:pointer; font-family: var(--ocs-font-family); }
+.copy-pill { position:absolute; top:0; right:0; background:#fff; border:1px solid #ccc; border-radius:12px; padding:4px 8px; cursor:pointer; box-shadow:0 2px 4px rgba(0,0,0,0.1); font-family: var(--ocs-font-family); }
 .copy-pill.fixed { position:fixed; top:10px; right:10px; }
 @keyframes copyFlash { 0%{background:var(--ocs-anim-color-start);}50%{background:var(--ocs-anim-color-end);}100%{background:transparent;} }
 .copy-anim { animation:copyFlash var(--ocs-anim-duration) ease-out; }
@@ -33,11 +34,14 @@
   padding: 20px;
   border-radius: 4px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  font-family: var(--ocs-font-family);
+  position: relative;
 }
 
 .ocs-modal input {
   width: 200px;
   font-size: 16px;
+  font-family: var(--ocs-font-family);
 }
 
 /* Search results */
@@ -52,10 +56,12 @@
 .ocs-results li {
   padding: 4px 8px;
   cursor: pointer;
+  font-family: var(--ocs-font-family);
 }
 
 .ocs-results li.highlight {
   background: #eee;
+  font-family: var(--ocs-font-family);
 }
 
 /* Small toast-style notification */
@@ -70,4 +76,61 @@
   font-size: 12px;
   z-index: 10000;
   opacity: 0.9;
+  font-family: var(--ocs-font-family);
+}
+
+/* Shared UI elements for popup and options */
+body.ocs-ui {
+  font-family: var(--ocs-font-family);
+  margin: 10px;
+  min-width: 280px;
+}
+
+.logo {
+  width: 32px;
+  height: 32px;
+  margin-right: 8px;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.form-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+}
+
+.form-row label {
+  flex: 1 0 140px;
+}
+
+.form-row input {
+  flex: 2 0 160px;
+}
+
+.snippet-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 4px 0;
+}
+
+.snippet-row .hotkey {
+  font-size: 12px;
+  opacity: 0.6;
+  margin-left: 8px;
+}
+
+.close-btn {
+  background: transparent;
+  border: none;
+  font-size: 20px;
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- restyle popup and options pages with consistent fonts
- add layout classes to `styles.css`
- implement a first-run guide in the popup
- include a close button for the search overlay

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687214d5481c832181243a7c58a6efe8