### PR TITLE
Fix docs selection listener

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -28,7 +28,8 @@
         "modules/storage.js",
         "content_script.js"
       ],
-      "css": [ "styles.css" ]
+      "css": [ "styles.css" ],
+      "all_frames": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- enable content script on all frames so selection listener works in Google Docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68722fbb78788321b326bb15e17f4ed2