### PR TITLE
Handle selectionchange events

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -87,22 +87,26 @@ function updateHotkeyMap() {
 // —— EVENT WIRES ——
 
 // 1) Selection detection → show button
+function maybeShowSnippetButton() {
+    if (typeof location === 'undefined' || !location.hostname.includes('docs.google.com')) {
+        return;
+    }
+    const sel = window.getSelection();
+    if (!sel || sel.isCollapsed || sel.rangeCount === 0) {
+        removeSnippetButton();
+        return;
+    }
+    const rect = sel.getRangeAt(0).getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) {
+        removeSnippetButton();
+        return;
+    }
+    showSnippetButton(rect);
+}
+
 if (typeof document !== 'undefined') {
-    document.addEventListener('mouseup', () => {
-        if (typeof location !== 'undefined' && location.hostname.includes('docs.google.com')) {
-            const sel = window.getSelection();
-            if (!sel || sel.isCollapsed || sel.rangeCount === 0) {
-                removeSnippetButton();
-                return;
-            }
-            const rect = sel.getRangeAt(0).getBoundingClientRect();
-            if (rect.width === 0 && rect.height === 0) {
-                removeSnippetButton();
-                return;
-            }
-            showSnippetButton(rect);
-        }
-    });
+    document.addEventListener('mouseup', maybeShowSnippetButton);
+    document.addEventListener('selectionchange', maybeShowSnippetButton);
 
     // 2) Delegate button clicks
     document.addEventListener('click', (e) => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,6 @@
 module.exports = {
   testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    url: 'https://docs.google.com'
+  }
 };

--- a/tests/overlay.test.js
+++ b/tests/overlay.test.js
@@ -53,4 +53,22 @@ describe('leader overlay and hotkeys', () => {
     document.dispatchEvent(evt);
     expect(global.navigator.clipboard.writeText).toHaveBeenCalledWith('Foo');
   });
+
+  test('selectionchange shows snippet button', () => {
+    document.body.innerHTML = '<p id="p">Hello world</p>';
+    const p = document.getElementById('p');
+    const text = p.firstChild;
+    const range = document.createRange();
+    range.setStart(text, 0);
+    range.setEnd(text, 5);
+    Range.prototype.getBoundingClientRect = () => ({ width: 10, height: 10, left: 0, top: 0 });
+    const sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+
+    document.dispatchEvent(new Event('selectionchange'));
+
+    const btn = document.getElementById('ocs-snippet-button');
+    expect(btn).not.toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- trigger snippet button on `selectionchange`
- run jest in a Google Docs-like environment
- test snippet button display via selectionchange

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68731759a67c83218e554351855f1207