### PR TITLE
Allow snippet button logic in any frame

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -88,7 +88,7 @@ function updateHotkeyMap() {
 
 // 1) Selection detection → show button
 function maybeShowSnippetButton() {
-    if (typeof location === 'undefined' || !location.hostname.includes('docs.google.com')) {
+    if (typeof location === 'undefined') {
         return;
     }
     let sel = window.getSelection();


### PR DESCRIPTION
## Summary
- run snippet show/hide logic regardless of the host frame

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687467b78b908321a059ef7ebcd7cce0